### PR TITLE
perf: make replacer plugin happy

### DIFF
--- a/vite-plugins/replacer/index.ts
+++ b/vite-plugins/replacer/index.ts
@@ -1,4 +1,5 @@
-import type { PluginOption } from 'vite'
+import type { FilterPattern, PluginOption } from 'vite'
+import { createFilter } from 'vite'
 
 export interface ReplacerOptions {
   /**
@@ -8,11 +9,11 @@ export interface ReplacerOptions {
   /**
    * @default [/node_modules/, /\.(png|jpe?g|gif|svg|ico)$/i]
    */
-  exclude?: (string | RegExp)[]
+  exclude?: FilterPattern
   /**
    * @default []
    */
-  include?: (string | RegExp)[]
+  include?: FilterPattern
   /**
    * require declaration in the first line of code, like:
    * ```ts
@@ -38,14 +39,12 @@ export function replacer(options?: ReplacerOptions): PluginOption {
     include = [],
     requireDeclaration = true
   } = options ?? {}
+  const filter = createFilter(include, exclude)
   return {
     name: 'replacer',
     enforce: 'pre',
     transform(code, id) {
-      if (exclude.some(pattern => pattern instanceof RegExp ? pattern.test(id) : pattern === id))
-        return
-      if (include.length > 0 && !include.some(pattern => pattern instanceof RegExp ? pattern.test(id) : pattern === id))
-        return
+      if (!filter(id)) return
       if (code.startsWith('// @replacer.disable'))
         return
 

--- a/vite-plugins/replacer/package.json
+++ b/vite-plugins/replacer/package.json
@@ -36,7 +36,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "esbuild --bundle --platform=node --target=node12 --outfile=index.js index.ts && tsc --emitDeclarationOnly --declaration --declarationMap --outDir .",
+    "build": "esbuild --bundle --platform=node --target=node12 --external:vite --outfile=index.js index.ts && tsc --emitDeclarationOnly --declaration --declarationMap --outDir .",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
# Background

We won't need to implement filtering manually. After vite(3.0.0). Vite has provided `createFilter`.
[Full changelog](https://github.com/vitejs/vite/blob/create-vite%404.4.1/packages/vite/CHANGELOG.md#features-7)
