### PR TITLE
chore: bump vite-plugin-cdn2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sentinel-js": "^0.0.7",
     "typescript": "^5.1.6",
     "vite": "^4.4.0",
-    "vite-plugin-cdn2": "^0.11.3",
+    "vite-plugin-cdn2": "^0.12.0",
     "vite-plugin-inspect": "^0.7.38"
   },
   "engines": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -111,9 +111,7 @@ export default defineConfig(async env => ({
               if (node.url?.size) {
                 const normal = Array.from( node.url.values())[0]
                 node.url = new Set()
-                node.extra.spare.forEach((el:string) => {
-                  node.url?.add(new URL(`${node.extra.name}@${node.extra.version}/${el}`, unpkg).href)
-                })
+                node.extra.spare.forEach((el:string) => node.url?.add(new URL(`${node.extra.name}@${node.extra.version}/${el}`, unpkg).href))
                 node.url.add(normal)
               }
             }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,8 +102,24 @@ export default defineConfig(async env => ({
         { name: '@babel/standalone', relativeModule: './babel.min.js' },
         { name: 'react', relativeModule: './umd/react.production.min.js' },
         { name: 'react-dom', relativeModule: './umd/react-dom.production.min.js' },
-        { name: 'jotai', relativeModule: './umd/index.production.js' }
-      ]
+        { name: 'jotai', relativeModule: './umd/index.production.js', spare: ['umd/vanilla.production.js', 'umd/react.production.js'] }
+      ],
+      transform() {
+        return {
+          script(node) {
+            if (node.name === 'jotai') {
+              if (node.url?.size) {
+                const normal = Array.from( node.url.values())[0]
+                node.url = new Set()
+                node.extra.spare.forEach((el:string) => {
+                  node.url?.add(new URL(`${node.extra.name}@${node.extra.version}/${el}`, unpkg).href)
+                })
+                node.url.add(normal)
+              }
+            }
+          }
+        }
+      }
     }),
     env.mode === 'production' ? visualizer() : undefined,
     process.env.ENABLE_INJECT_ANALYTICS === 'true' ? inspect() : undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,11 +1205,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css.escape@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
-  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
-
 csstype@^3.0.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
@@ -1290,11 +1285,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-entities@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
-  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 error-stack-parser-es@^0.1.1:
   version "0.1.1"
@@ -1736,18 +1726,6 @@ graphemer@^1.4.0:
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-happy-dom@^10.10.0:
-  version "10.10.0"
-  resolved "https://registry.npmjs.org/happy-dom/-/happy-dom-10.10.0.tgz#46cb9755e51032595556c50edee778149caf7b90"
-  integrity sha512-rpWFSemZoid3OKuzMs47CDUOnAYV10vYlXaVBPD+dBDHTAFkyIIpkHXx8gd/uWMyf+XOluQNnxImWp17SprE2Q==
-  dependencies:
-    css.escape "^1.5.1"
-    entities "^4.5.0"
-    iconv-lite "^0.6.3"
-    webidl-conversions "^7.0.0"
-    whatwg-encoding "^2.0.0"
-    whatwg-mimetype "^3.0.0"
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -1784,13 +1762,6 @@ human-signals@^4.3.0:
   version "4.3.1"
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
   integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
-
-iconv-lite@0.6.3, iconv-lite@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
-  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^5.2.0:
   version "5.2.4"
@@ -2046,11 +2017,6 @@ minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimist@^1.2.6:
-  version "1.2.8"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
-  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 monaco-editor@^0.40.0:
   version "0.40.0"
@@ -2422,11 +2388,6 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-"safer-buffer@>= 2.1.2 < 3.0.0":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
 sass@^1.64.0:
   version "1.64.2"
   resolved "https://registry.npmjs.org/sass/-/sass-1.64.2.tgz#0d9805ad6acf31c59c3acc725fcfb91b7fcc6909"
@@ -2564,11 +2525,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
-
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
@@ -2634,15 +2590,6 @@ ts-toolbelt@^9.6.0:
   version "9.6.0"
   resolved "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
   integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
-
-tsconfig-paths@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"
-  integrity sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==
-  dependencies:
-    json5 "^2.2.2"
-    minimist "^1.2.6"
-    strip-bom "^3.0.0"
 
 tslib@^1.8.1:
   version "1.14.1"
@@ -2733,15 +2680,14 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-vite-plugin-cdn2@^0.11.3:
-  version "0.11.3"
-  resolved "https://registry.npmjs.org/vite-plugin-cdn2/-/vite-plugin-cdn2-0.11.3.tgz#9b1a605fd62a862d427ca82f58b522d1ac0a4ed1"
-  integrity sha512-nx4RoSFaFUrRAlpZbrlZueEwZWfFqpu/lpxVGOAJtBW/KxR+UGmkNMHJqZG7g8sxwoK1Y75O3eNLzSbmjEoZew==
+vite-plugin-cdn2@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-cdn2/-/vite-plugin-cdn2-0.12.0.tgz#8e772c7a40d6ef590870cd84c19a838648fb4734"
+  integrity sha512-biOZkhpUjutik34ItttyK2sujSrg8xDE0Rof5AZ5Vu1K+mRM7n8SmHsXwoBrOcfLMjGswbcxhBFdbbKznYZqrQ==
   dependencies:
     "@babel/core" "^7.22.5"
     "@rollup/pluginutils" "^5.0.2"
     debug "^4.3.4"
-    happy-dom "^10.10.0"
     rs-module-lexer "^1.0.0"
 
 vite-plugin-inspect@^0.7.38:
@@ -2768,23 +2714,6 @@ vite@^4.4.0:
     rollup "^3.25.2"
   optionalDependencies:
     fsevents "~2.3.2"
-
-webidl-conversions@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
-  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
-
-whatwg-encoding@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
-  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
-  dependencies:
-    iconv-lite "0.6.3"
-
-whatwg-mimetype@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
-  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
# Background

`vite-plugin-cdn2` version `0.12.0` has been released. This version drop `happy-dom`. It can reduce installer size.

## Patches

- Fix `jotai`  can't scanner. Jotai needs three module for production.

## Others

https://github.com/nonzzz/vite-plugin-cdn/issues/18