### PR TITLE
fix: keep cursor when switch language

### DIFF
--- a/core/src/components/EditorZone.tsx
+++ b/core/src/components/EditorZone.tsx
@@ -110,6 +110,21 @@ export default function EditorZone(props: {
 
   const [displayLeftBar, setDisplayLeftBar] = useAtom(displayLeftBarAtom)
 
+  const editorCursorPosition = useRef<monacoEditor.Position | null>(null)
+
+  useEffect(() => {
+    if (editor) {
+      // restore cursor position
+      editor.setPosition(editorCursorPosition.current ?? { lineNumber: 1, column: 1 })
+      editor.focus()
+
+      return () => {
+        // save current cursor position
+        editorCursorPosition.current = editor.getPosition() ?? null
+      }
+    }
+  }, [language, editor])
+
   useEffect(() => {
     if (!monaco || !editor) return
 


### PR DESCRIPTION
Because app use different file path `index.js` and `index.ts` to implement different language, the cursor position wouldn't sync between the files.

This PR implement cursor position restore and editor focus after switch language to provide better UX