### PR TITLE
feat: add bootstrap script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "serve": "vite",
     "build": "vite build",
     "build:watch": "vite build --watch",
-    "preview": "vite preview"
+    "build:replacer":"yarn --cwd vite-plugins/replacer build",
+    "preview": "vite preview",
+    "bootstrap": "node scripts/bootstrap.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,4 +1,3 @@
-import { Buffer } from 'node:buffer'
 import child_process from 'node:child_process'
 import process from 'node:process'
 
@@ -11,18 +10,13 @@ const defaultOptions = {
 function execa(command, argvs = [], options = defaultOptions) {
   return new Promise((resolve, reject) => {
     const cp = child_process.spawn(command, argvs, options)
-    const stdout = []
-    const stderr = []
-    cp.stdout.on('data', (data) => stdout.push(data))
-    cp.stderr.on('data', (err) => stderr.push(err))
     cp.on('error', reject)
     cp.on('close', (code) => {
       if (code !== 0) {
         const error = new Error(`Command failed with exit code ${code}`)
-        error.stdout = Buffer.from(stdout).toString()
-        error.stderr = Buffer.from(stderr).toString()
+        reject(error)
       } else {
-        resolve({ stdout: Buffer.from(stdout), stderr: Buffer.from(stderr) })
+        resolve()
       }
     })
   })

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,0 +1,37 @@
+import { Buffer } from 'node:buffer'
+import child_process from 'node:child_process'
+import process from 'node:process'
+
+const defaultOptions = {
+  cwd: process.cwd(),
+  shell: process.platform === 'win32',
+  stdio: 'inherit'
+}
+
+function execa(command, argvs = [], options = defaultOptions) {
+  return new Promise((resolve, reject) => {
+    const cp = child_process.spawn(command, argvs, options)
+    const stdout = []
+    const stderr = []
+    cp.stdout.on('data', (data) => stdout.push(data))
+    cp.stderr.on('data', (err) => stderr.push(err))
+    cp.on('error', reject)
+    cp.on('close', (code) => {
+      if (code !== 0) {
+        const error = new Error(`Command failed with exit code ${code}`)
+        error.stdout = Buffer.from(stdout).toString()
+        error.stderr = Buffer.from(stderr).toString()
+      } else {
+        resolve({ stdout: Buffer.from(stdout), stderr: Buffer.from(stderr) })
+      }
+    })
+  })
+}
+
+async function main() {
+  await execa('yarn', ['install'])
+  await execa('yarn', ['build:replacer'])
+}
+
+
+main()


### PR DESCRIPTION
# Background

As we develop this project. we need run `yarn install` then entr plugins directory and  run `yarn build`. I write a script to simplify it. Now we only run `yarn bootstrap` is enough.

## TODO

Maybe there will be many plugins in the future where we can retain the ability to accept stdin.