### PR TITLE
fix(core): fix editor position problem with firefox

### DIFF
--- a/core/src/components/base/Dialog.scss
+++ b/core/src/components/base/Dialog.scss
@@ -17,7 +17,6 @@ dialog.ppd-dialog {
 
   transition: .3s;
   & {
-    display: block;
     pointer-events: none;
     visibility: hidden;
   }


### PR DESCRIPTION
Position of the editor is weird in Firefox (Version 126.0). 

![图片](https://github.com/Power-Playground/app/assets/17609073/53369c9a-594b-4de4-9a55-9a99b24d03d8)
